### PR TITLE
remove occurrences of px from components

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -117,6 +117,7 @@ glob(`${rootDir}/src/feather/icons/**.svg`, (err, icons) => {
         .replace(new RegExp('</defs', 'g'), '</Defs')
         .replace(new RegExp('<stop', 'g'), '<Stop')
         .replace(new RegExp('</stop', 'g'), '</Stop')
+        .replace(new RegExp('px', 'g'), '')
       }
         )
       };


### PR DESCRIPTION
React Native doesn't use pixels for its dimensions, so it is important to remove them if they have been defined as such.